### PR TITLE
Update base image to Python 3.13-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-bookworm
 
 RUN apt-get update && apt-get install -y graphviz
 


### PR DESCRIPTION
In some cases, this image was running into this issue: https://github.com/python/cpython/issues/108525, possibly due to using the `slim` base. This commit both updates python to the latest stable (3.13) and siwtches to the `bookworm` base.